### PR TITLE
Maintenance updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,5 +28,7 @@ jobs:
         run: ruff format --check .
           
       - name: pytest
-        run: |
-          python -m pytest --capture=no tests/
+        run: coverage run -m pytest
+
+      - name: coverage
+        run: coverage report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
 
-      - name: ruff
-        run: |
-          ruff check --output-format=github .
+      - name: Ruff Check
+        run: ruff check --output-format=github .
 
-      - name: black
-        run: |
-          black --check .
+      - name: Ruff Format
+        run: ruff format --check .
           
       - name: pytest
         run: |

--- a/picofun/cli.py
+++ b/picofun/cli.py
@@ -11,11 +11,6 @@ import picofun.spec
 import picofun.template
 import picofun.terraform_generator
 
-# fmt: off
-# Hack to stop black and typer fighting over the type annotations
-OptionalString = typing.Optional[str]
-# fmt: on
-
 app = typer.Typer()
 
 
@@ -28,16 +23,18 @@ def main(
         str, typer.Argument(help="URL or path to the OpenAPI spec file")
     ],
     config_file: typing.Annotated[
-        OptionalString, typer.Option(help="Full path to the configuration file")
+        typing.Optional[str], typer.Option(help="Full path to the configuration file")
     ] = None,
     output_dir: typing.Annotated[
-        OptionalString, typer.Option(help="Directory to output the generated files")
+        typing.Optional[str],
+        typer.Option(help="Directory to output the generated files"),
     ] = None,
     layers: typing.Annotated[
-        OptionalString, typer.Option(help="Comma separated list of Lambda layer ARNs")
+        typing.Optional[str],
+        typer.Option(help="Comma separated list of Lambda layer ARNs"),
     ] = "",
     bundle: typing.Annotated[
-        OptionalString,
+        typing.Optional[str],
         typer.Option(
             help="Path to code to bundle into a layer. If requirements.txt present pip install will be run."
         ),

--- a/picofun/lambda_generator.py
+++ b/picofun/lambda_generator.py
@@ -29,12 +29,8 @@ class LambdaGenerator:
         self._config = config
 
         self.max_length = 64 - len(f"{namespace}_")
-        self.prefix_length = (
-            # Remove one for the underscore between the prefix and the suffix.
-            self.max_length
-            - LAMBDA_SUFFIX_LENGTH
-            - 1
-        )
+        # Remove one for the underscore between the prefix and the suffix.
+        self.prefix_length = self.max_length - LAMBDA_SUFFIX_LENGTH - 1
 
     def _get_name(self, method: str, path: str) -> str:
         clean_path = path.replace("{", "").replace("}", "")

--- a/picofun/spec.py
+++ b/picofun/spec.py
@@ -126,7 +126,8 @@ class YAMLSpecParser(SpecParser):
         patched_loader = self.patch_loader(loader)
         try:
             return yaml.load(
-                content, Loader=patched_loader  # noqa: S506 Uses a patched safe loader
+                content,
+                Loader=patched_loader,  # noqa: S506 Uses a patched safe loader
             )
         except yaml.YAMLError as e:
             raise picofun.errors.InvalidSpecError() from e

--- a/picofun/template.py
+++ b/picofun/template.py
@@ -15,12 +15,8 @@ class Template:
             base_path = os.path.join(os.getcwd(), base_path)
 
         path = os.path.realpath(base_path)
-
-        self._environment = (
-            jinja2.Environment(  # noqa: S701 We're not generating HTML # nosec
-                loader=jinja2.FileSystemLoader(path)
-            )
-        )
+        loader = jinja2.FileSystemLoader(path)
+        self._environment = jinja2.Environment(loader=loader)  # noqa: S701 We're not generating HTML # nosec
 
         self.templates = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dynamic = ["version"]
 [project.optional-dependencies]
 
 dev = [
+  "coverage==7.6.3",
   "pytest==8.3.3",
-  "pytest-cov==5.0.0",
   "pytest-mock==3.14.0",
   "ruff==0.7.0",
 ]
@@ -70,9 +70,6 @@ exclude = '''
   | \.nox
 )
 '''
-
-[tool.pytest.ini_options]
-addopts = "--cov --cov-report term-missing"
 
 [tool.ruff.lint]
 # Rules listed at https://github.com/charliermarsh/ruff#supported-rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 description = "PicoFun AWS Lambda generator"
 
 dependencies = [
-  "black==24.8.0",
+  "black==24.10.0", # ruff can't be invoked from code without shelling out
   "jinja2==3.1.4",
   "PyYAML==6.0.2",
   "requests==2.32.3",
@@ -25,7 +25,7 @@ dev = [
   "pytest==8.3.3",
   "pytest-cov==5.0.0",
   "pytest-mock==3.14.0",
-  "ruff==0.6.4",
+  "ruff==0.7.0",
 ]
 
 build = [
@@ -77,7 +77,7 @@ addopts = "--cov --cov-report term-missing"
 [tool.ruff.lint]
 # Rules listed at https://github.com/charliermarsh/ruff#supported-rules
 select = ["B", "D", "E", "F", "G", "I", "N", "S", "W", "ANN" ,"BLE", "C4", "C90", "DTZ", "ERA", "PLW", "PT", "RET", "RUF", "SIM", "TRY", "UP"]
-ignore = ["D203", "D212", "E501", "F403", "F405", "ANN101"]
+ignore = ["D203", "D211", "D212", "E501", "F403", "F405", "ANN101"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["B", "D", "E", "F", "G", "I", "N", "S", "W", "ANN" ,"BLE", "C4", "C90", "DTZ", "ERA", "PLW", "PT", "RET", "RUF", "SIM", "TRY", "UP"]
@@ -85,3 +85,4 @@ unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S108"]
+"output" = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ enabled = true
 
 [tool.black]
 line-length = 88
-target-version = ['py310']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/templates/main.tf.j2
+++ b/templates/main.tf.j2
@@ -61,7 +61,7 @@ resource "null_resource" "layer" {
       rm -rf ${local.lambda_layer_path}
       mkdir -p ${local.lambda_layer_path}/python
       cp -a ${path.module}/layer/. ${local.lambda_layer_path}/python
-      pip3.10 install -r ${local.lambda_layer_path}/python/requirements.txt --target ${local.lambda_layer_path}/python
+      pip3.12 install -r ${local.lambda_layer_path}/python/requirements.txt --target ${local.lambda_layer_path}/python
     EOT
   }
 
@@ -85,7 +85,7 @@ resource "aws_lambda_layer_version" "this" {
   layer_name          = "{{ namespace }}"
   source_code_hash    = data.archive_file.layer.output_base64sha256
 
-  compatible_runtimes      = ["python3.10"]
+  compatible_runtimes      = ["python3.12"]
   compatible_architectures = ["x86_64"]
 
   lifecycle {
@@ -108,7 +108,7 @@ resource "aws_lambda_function" "this" {
   function_name    = "{{ namespace }}_${each.value}"
   role             = aws_iam_role.lambda.arn
   handler          = "${each.value}.handler"
-  runtime          = "python3.10"
+  runtime          = "python3.12"
   source_code_hash = data.archive_file.lambda[each.value].output_base64sha256
   timeout          = 10
   layers           = local.layers

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -7,9 +7,7 @@ import picofun.errors
 import picofun.spec
 
 
-def mock_requests_get_spec(
-    *args: list, **kwargs: dict
-) -> "MockResponse":  # noqa: F821 class defined in this function
+def mock_requests_get_spec(*args: list, **kwargs: dict) -> "MockResponse":  # noqa: F821
     """
     Mock requests.get() responses.
 


### PR DESCRIPTION
* Python 3.10 -> 3.12
* black to ruff for formatting code (black is still used to format the generated code)
* pytest-cov to coverage.py so we can use newer versions of pytest
* Bump black and ruff versions