### PR TITLE
BREAKING: Refactor config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ output_dir="/path/to/write/output-files" # default is current-working-directory/
 postprocessor="fully.qualified.reference.to.postprocessor" # default is none
 preprocessor="fully.qualified.reference.to.preprocessor" # default is none
 role_permissions_boundary="arn:aws:iam::012345678910:policy/..." # default is none
-subnets=[ # default is none. Unless specified VPC networking is not enabled
+subnets=[ # default is none. Must be set if vpc_id is set
   "subnet-1234567890abcdef0",
   "subnet-234567890abcdef01"
 ]
 template_path="/path/to/templates" # default is current-working-directory/templates
 xray_tracing=false # default is to enable xray tracing, set this to false to turn it off
-
+vpc_id = "vpc-0011223344556677f" # Default is none. Must be set if using subnets
 [tags] # defaults to none
 key="value"
 anotherKey="some other value"

--- a/example/picofun.toml
+++ b/example/picofun.toml
@@ -2,6 +2,7 @@ bundle = "helpers"
 iam_role_prefix = "pf-example-"
 preprocessor = "zendesk_common.preprocessor.preprocess"
 subnets=["subnet-707a1eeloaded", "subnet-d3adb33f", "subnet-badcafe"]
+vpc_id = "vpc-0011223344556677f"
 
 [tags]
 app = "picofun-zendesk"

--- a/picofun/cli.py
+++ b/picofun/cli.py
@@ -41,7 +41,7 @@ def main(
     ] = None,
 ) -> None:
     """Generate lambda functions and terraform configuration to call REST APIs."""
-    config = picofun.config.Config(config_file)
+    config = picofun.config.ConfigLoader(config_file).get_config()
     config.merge(
         output_dir=output_dir,
         layers=layers,

--- a/picofun/config.py
+++ b/picofun/config.py
@@ -5,179 +5,274 @@ import typing
 from importlib.resources import files
 
 import tomli as toml
+from pydantic import (
+    BaseModel,
+    DirectoryPath,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 import picofun.errors
 
 AWS_POWER_TOOLS_LAYER_ARN = "arn:aws:lambda:us-east-1:017000801446:layer:AWSLambdaPowertoolsPythonV3-python312-arm64:2"
 
 
-class Config:
+class Config(BaseModel, extra="forbid", validate_assignment=True):
     """Configuration management class."""
 
-    _attrs: typing.ClassVar[dict[str : typing.Any]] = {
-        "_config_file": str,
-        "bundle": str,
-        "iam_role_prefix": str,
-        "layers": list,
-        "output_dir": str,
-        "postprocessor": str,
-        "preprocessor": str,
-        "role_permissions_boundary": str,
-        "subnets": list,
-        "tags": dict,
-        "template_path": str,
-        "xray_tracing": bool,
-    }
+    bundle: str = None
+    iam_role_prefix: str = "pf-"
+    layers: list[str] = [AWS_POWER_TOOLS_LAYER_ARN]
+    output_dir: DirectoryPath = os.path.realpath(os.path.join(os.getcwd(), "output"))
+    postprocessor: str = ""
+    preprocessor: str = ""
+    role_permissions_boundary: str = None
+    subnets: list[str] = []
+    tags: dict[str, typing.Any] = {}
+    template_path: DirectoryPath = os.path.join(files("picofun"), "templates")
+    vpc_id: str = None
+    xray_tracing: bool = True
+
+    @model_validator(mode="after")
+    def validate_subnets_vpc(self) -> "Config":
+        """
+        Check if subnets and vpc are set together.
+
+        Raises
+        ------
+            ValueError: If subnets is set without vpc.
+
+        """
+        if (self.subnets and not self.vpc_id) or (self.vpc_id and not self.subnets):
+            raise ValueError("Both subnets and vpc must be set, if one is set")  # noqa TRY003 This is a valid use case for a ValueError.
+
+        return self
+
+    @field_validator("bundle", mode="before")
+    @classmethod
+    def validate_bundle(cls: "Config", value: str) -> str:
+        """
+        Check if bundle is a valid path.
+
+        Args:
+        ----
+            value: The value to validate.
+
+        Returns:
+        -------
+            str: The validated value.
+
+        """
+        if not os.path.isabs(value):
+            bundle_path = os.path.realpath(os.path.join(os.getcwd(), value))
+        else:
+            bundle_path = os.path.realpath(value)
+
+        if not os.path.exists(bundle_path):
+            raise ValueError(f"Bundle path not found: {bundle_path}")  # noqa TRY003 This is a valid use case for a ValueError.
+
+        return bundle_path
+
+    @field_validator("layers", mode="before")
+    @classmethod
+    def validate_layers(
+        cls: "Config", value: typing.Union[str | list[str]]
+    ) -> list[str]:
+        """
+        Check if layers is a list of strings.
+
+        Convert a string to a list of strings if necessary.
+
+        Args:
+        ----
+            value: The value to validate.
+
+        Returns:
+        -------
+            list[str]: The validated value.
+
+        """
+        layers = []
+        print(f"Type: {type(value)} Value: {value}")
+        if isinstance(value, str):
+            layers = [item.strip() for item in value.split(",") if item.strip()]
+
+        if isinstance(value, list):
+            layers = value
+
+        if (
+            len([layer for layer in layers if "awslambdapowertools" in layer.lower()])
+            == 0
+        ):
+            layers.insert(0, AWS_POWER_TOOLS_LAYER_ARN)
+
+        return layers
+
+    @field_validator("output_dir", mode="before")
+    @classmethod
+    def validate_output_dir(cls: "Config", value: str) -> str:
+        """
+        Check if output_dir is a valid path.
+
+        Args:
+        ----
+            value: The value to validate.
+
+        Returns:
+        -------
+            str: The validated value.
+
+        """
+        if os.path.isabs(value):
+            output_dir = os.path.realpath(value)
+        else:
+            output_dir = os.path.realpath(os.path.join(os.getcwd(), value))
+
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        return output_dir
+
+    @field_validator("subnets", mode="before")
+    @classmethod
+    def validate_subnets(
+        cls: "Config", value: typing.Union[str | list[str]]
+    ) -> list[str]:
+        """
+        Check if subnets is a list of strings.
+
+        Convert a string to a list of strings if necessary.
+
+        Args:
+        ----
+            value: The value to validate.
+
+        Returns:
+        -------
+            list[str]: The validated value.
+
+        """
+        subnets = []
+        if isinstance(value, str):
+            subnets = [item.strip() for item in value.split(",") if item.strip()]
+
+        if isinstance(value, list):
+            subnets = value
+
+        if len([subnet for subnet in subnets if subnet[:7] != "subnet-"]) != 0:
+            raise ValueError("Subnets must be in the format 'subnet-[hex]'")  # noqa TRY003 This is a valid use case for a ValueError.
+
+        return subnets
+
+    @field_validator("template_path", mode="before")
+    @classmethod
+    def validate_template_path(cls: "Config", value: str) -> str:
+        """
+        Check if template is a valid path.
+
+        Args:
+        ----
+            value: The value to validate.
+
+        Returns:
+        -------
+            str: The validated value.
+
+        """
+        if not os.path.isabs(value):
+            template_path = os.path.realpath(os.path.join(os.getcwd(), value))
+        else:
+            template_path = os.path.realpath(value)
+
+        if not os.path.exists(os.path.join(template_path, "main.tf.j2")):
+            raise ValueError(f"Template path not found: {template_path}")  # noqa TRY003 This is a valid use case for a ValueError.
+
+        return template_path
+
+    def merge(self, **kwargs: dict[str, typing.Any]) -> None:
+        """
+        Merge the existing configuration with a dictionary of values.
+
+        Args:
+        ----
+            kwargs: The CLI arguments.
+
+        """
+        for key in kwargs:
+            if kwargs[key]:
+                setattr(self, key, kwargs[key])
+
+
+class ConfigLoader:
+    """Configuration management class."""
 
     def __init__(self, file_path: typing.Optional[str] = None) -> None:
         """
         Initialize the configuration.
 
-        :param file_path: The path to the configuration file.
+        Args:
+        ----
+            file_path: The path to the configuration file.
+
         """
-        self.set_defaults()
         self._config_file = self._get_config_file(file_path)
-        self.load_from_file(self._config_file)
+        self._config = self.load_from_file(self._config_file)
 
     def _get_config_file(self, config_file: typing.Optional[str] = None) -> str:
-        """Get the path to the configuration file."""
+        """
+        Get the path to the configuration file.
+
+        Args:
+        ----
+            config_file: The path to the configuration file.
+
+        Returns:
+        -------
+            The path to the configuration file.
+
+        """
         if not config_file:
             config_file = os.getcwd()
 
         if os.path.isdir(config_file):
             config_file = os.path.join(config_file, "picofun.toml")
 
-        if os.path.isfile(config_file):
-            return config_file
+        return config_file
 
-        raise picofun.errors.ConfigFileNotFoundError(config_file)
-
-    def __getattr__(self, name: str) -> str | list | dict[str, typing.Any]:
+    def get_config(self) -> Config:
         """
-        Get a configuration value.
+        Get the configuration object.
 
-        :param name: The name of the configuration value.
-        :return: The configuration value.
+        Returns
+        -------
+            The configuration object.
+
         """
-        if name not in self._attrs:
-            raise picofun.errors.UnknownConfigValueError(name)
-
-    def __setattr__(self, name: str, value: str | list | dict[str, typing.Any]) -> None:
-        """
-        Set a configuration value.
-
-        :param name: The name of the configuration value.
-        :param value: The value to set.
-        """
-        if name not in self._attrs:
-            raise picofun.errors.UnknownConfigValueError(name)
-
-        # First allow layers to be set as a comma separated string and convert it to a list
-        if name == "layers":
-            if isinstance(value, str):
-                value = [raw.strip() for raw in value.split(",")]
-                if value == [""]:
-                    value = []
-
-            if (
-                len([item for item in value if "awslambdapowertools" in item.lower()])
-                == 0
-            ):
-                value.append(AWS_POWER_TOOLS_LAYER_ARN)
-
-        if not isinstance(value, self._attrs[name]):
-            raise picofun.errors.InvalidConfigTypeError(name, value, self._attrs[name])
-
-        if name == "bundle" and value:
-            value = self._fix_bundle_path(value)
-
-        if name == "output_dir":
-            value = self._fix_target_path(value)
-            # Ensure the path exists
-            if not os.path.exists(value):
-                os.makedirs(value, exist_ok=True)
-
-        self.__dict__[name] = value
-
-    def _fix_bundle_path(self, bundle_path: str) -> str:
-        """
-        Fix the bundle path to ensure it is absolute.
-
-        :param bundle_path: The path to the bundle.
-        :return: The absolute path to the bundle.
-        """
-        if not os.path.isabs(bundle_path):
-            bundle_path = os.path.join(os.path.dirname(self._config_file), bundle_path)
-
-        return os.path.realpath(bundle_path)
-
-    def _fix_target_path(self, output_dir: str = "") -> str:
-        """
-        Fix the target path to ensure it is absolute.
-
-        :param output_dir: The name of the output directory
-        :return: The absolute path to the output directory
-        """
-        if os.path.isabs(output_dir):
-            return os.path.realpath(output_dir)
-
-        return os.path.realpath(os.path.join(os.getcwd(), output_dir))
+        return self._config
 
     def load_from_file(self, path: str) -> None:
         """
         Load configuration from toml file.
 
-        :param path: The path to the configuration file.
-        :return: The configuration.
+        Args:
+        ----
+            path: The path to the configuration file.
+
+        Returns:
+            The configuration object.
+
         """
         if not os.path.isfile(path):
             raise picofun.errors.ConfigFileNotFoundError(path=path)
 
         with open(path, "rb") as file:
             try:
-                file_config = toml.load(file)
+                contents = toml.load(file)
             except toml.TOMLDecodeError as e:
                 raise picofun.errors.InvalidConfigError() from e
 
-        self.merge(**file_config)
-
-    def merge(self, **kwargs: dict[str, typing.Any]) -> None:
-        """
-        Merge the configuration with the CLI arguments.
-
-        :param kwargs: The CLI arguments.
-        """
-        for key in kwargs:
-            if key not in self._attrs:
-                raise picofun.errors.UnknownConfigValueError(key)
-
-            if kwargs[key]:
-                setattr(self, key, kwargs[key])
-
-    def set_defaults(self) -> None:
-        """Set the default values for the configuration."""
-        defaults = {
-            "_config_file": "",
-            "bundle": None,
-            "iam_role_prefix": "pf-",
-            "layers": [AWS_POWER_TOOLS_LAYER_ARN],
-            "output_dir": os.path.realpath(os.path.join(os.getcwd(), "output")),
-            "postprocessor": "",
-            "preprocessor": "",
-            "role_permissions_boundary": None,
-            "subnets": [],
-            "tags": {},
-            "template_path": os.path.join(files("picofun"), "templates"),
-            "xray_tracing": True,
-        }
-
-        for key in defaults:
-            self.__dict__[key] = defaults[key]
-
-    def asdict(self) -> dict[str, typing.Any]:
-        """
-        Convert the configuration to a dictionary.
-
-        :return: The configuration dictionary.
-        """
-        return self.__dict__
+        try:
+            return Config(**contents)
+        except ValidationError as e:
+            raise picofun.errors.UnknownConfigValueError() from e

--- a/picofun/errors.py
+++ b/picofun/errors.py
@@ -77,6 +77,6 @@ class InvalidSpecError(Exception):
 class UnknownConfigValueError(AttributeError):
     """Exception thrown when an unknown configuration value is specified."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(self) -> None:
         """Initialise UnknownConfigValueError."""
-        super().__init__(name=name, obj="Config")
+        super().__init__("Invalid property found in config file.")

--- a/picofun/lambda_generator.py
+++ b/picofun/lambda_generator.py
@@ -26,7 +26,7 @@ class LambdaGenerator:
     ) -> None:
         """Initialize the lambda generator."""
         self._template = template
-        self._config = config
+        self._config = config.model_dump()
 
         self.max_length = 64 - len(f"{namespace}_")
         # Remove one for the underscore between the prefix and the suffix.
@@ -52,7 +52,7 @@ class LambdaGenerator:
         api_data: dict[str : typing.Any],
     ) -> list[str]:
         """Generate the lambda functions."""
-        output_dir = self._config.output_dir
+        output_dir = self._config["output_dir"]
 
         lambda_dir = os.path.join(output_dir, "lambdas")
         if not os.path.exists(lambda_dir):
@@ -90,14 +90,14 @@ class LambdaGenerator:
         self, base_url: str, method: str, path: str, details: dict[str : typing.Any]
     ) -> str:
         """Render the lambda function."""
-        preprocessor_handler = self._config.preprocessor
+        preprocessor_handler = self._config["preprocessor"]
         preprocessor = (
             ".".join(preprocessor_handler.split(".")[:-1])
             if preprocessor_handler
             else None
         )
 
-        postprocessor_handler = self._config.postprocessor
+        postprocessor_handler = self._config["postprocessor"]
         postprocessor = (
             ".".join(postprocessor_handler.split(".")[:-1])
             if postprocessor_handler
@@ -114,6 +114,6 @@ class LambdaGenerator:
             preprocessor_handler=preprocessor_handler,
             postprocessor=postprocessor,
             postprocessor_handler=postprocessor_handler,
-            xray_tracing=self._config.xray_tracing,
+            xray_tracing=self._config["xray_tracing"],
         )
         return black.format_str(code, mode=black.Mode())

--- a/picofun/templates/main.tf.j2
+++ b/picofun/templates/main.tf.j2
@@ -30,16 +30,10 @@ locals {
 {% endif %}
 }
 {% if subnets|length > 0 %}
-data "aws_subnet" "this" {
-  for_each = toset(local.subnet_ids)
-
-  id = each.value
-}
-
 resource "aws_security_group" "lambda" {
   name        = "pf-{{ namespace }}-lambdas"
   description = "Security group for pf-{{ namespace }} lambda functions"
-  vpc_id      = data.aws_subnet.this[local.subnet_ids[0]].vpc_id
+  vpc_id      = "{{ vpc_id }}"
 
   tags = var.tags
 }
@@ -96,6 +90,7 @@ resource "aws_lambda_function" "this" {
   filename         = data.archive_file.lambda[each.value].output_path
   function_name    = "{{ namespace }}_${each.value}"
   role             = aws_iam_role.lambda.arn
+  architectures    = ["arm64"]
   handler          = "${each.value}.handler"
   runtime          = "python3.12"
   source_code_hash = data.archive_file.lambda[each.value].output_base64sha256
@@ -104,7 +99,7 @@ resource "aws_lambda_function" "this" {
 {% if subnets|length > 0 %}
   vpc_config {
       security_group_ids = [aws_security_group.lambda.id]
-      subnet_ids         = [for subnet in data.aws_subnet.this: subnet.id]
+      subnet_ids         = [for subnet in local.subnet_ids: subnet]
   }
 {% endif %}
 {% if xray_tracing %}

--- a/picofun/terraform_generator.py
+++ b/picofun/terraform_generator.py
@@ -41,6 +41,7 @@ class TerraformGenerator:
             role_permissions_boundary=self._config.role_permissions_boundary,
             subnets=self._config.subnets,
             tags=self._config.tags,
+            vpc_id=self._config.vpc_id,
             xray_tracing=self._config.xray_tracing,
         )
         output_file = os.path.join(output_dir, "main.tf")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ description = "PicoFun AWS Lambda generator"
 dependencies = [
   "black==24.10.0", # ruff can't be invoked from code without shelling out
   "jinja2==3.1.4",
+  "pydantic==2.9.2",
   "PyYAML==6.0.2",
   "requests==2.32.3",
   "tomli==2.0.2",
@@ -52,6 +53,9 @@ packages = ["picofun"]
 
 [tool.setuptools-git-versioning]
 enabled = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.black]
 line-length = 88

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,117 +4,40 @@ import os
 import random
 import string
 import tempfile
+import typing
 
+import pydantic
 import pytest
 
 import picofun.config
 
 
-def test_config_load() -> None:
-    """Test loading a configuration file."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config.output_dir == os.path.realpath("tests/data/output")
-    assert config.layers == [
-        "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
-        picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
-    ]
-    assert config.template_path == "tests/data/templates"
-
-
-def test_config_load_empty() -> None:
-    """Test loading an empty configuration file."""
-    config = picofun.config.Config("tests/data/empty.toml")
-
-    assert config.output_dir == os.path.realpath(f"{os.getcwd()}/output")
-    assert config.layers == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
-
-
-def test_config_load_missing() -> None:
-    """Test loading a missing configuration file."""
-    with pytest.raises(picofun.errors.ConfigFileNotFoundError):
-        picofun.config.Config("tests/data/missing.toml")
-
-
-def test_config_load_invalid() -> None:
-    """Test loading an invalid configuration file."""
-    with pytest.raises(picofun.errors.InvalidConfigError):
-        picofun.config.Config("tests/data/invalid.toml")
-
-
-def test_config_load_invalid_value() -> None:
-    """Test loading an invalid configuration file."""
-    with pytest.raises(picofun.errors.UnknownConfigValueError):
-        picofun.config.Config("tests/data/invalid_type.toml")
-
-
-def test_config_load_relative_path() -> None:
-    """Test loading a configuration file with a relative path."""
-    config = picofun.config.Config("tests/data/config_relative.toml")
-
-    assert config.output_dir == os.path.realpath("tests/data/output")
-
-
-def test_config_load_relative_path_missing() -> None:
-    """Test loading a configuration file with a relative path."""
-    with pytest.raises(picofun.errors.ConfigFileNotFoundError):
-        picofun.config.Config("tests/data/missing.toml")
-
-
-def test_config_load_absolute_path_missing() -> None:
-    """Test loading a configuration file with an absolute path."""
-    with pytest.raises(picofun.errors.ConfigFileNotFoundError):
-        picofun.config.Config(
-            "/tmp/invalid/config/file/location/45c5391e-6e9a-496e-8694-9ef1a03addb3.toml"
-        )
-
-
 def test_config_getattr() -> None:
     """Test loading a configuration file."""
-    config = picofun.config.Config("tests/data/config.toml")
+    params = {"layers": ["arn:aws:lambda:us-east-1:012345678910:layer:example:1"]}
+    config = picofun.config.Config(**params)
 
     assert config.layers == [
-        "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
         picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
+        "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
     ]
 
 
 def test_config_getattr_invalid() -> None:
     """Test __getattr__ with an invalid property."""
-    config = picofun.config.Config("tests/data/config.toml")
-    with pytest.raises(picofun.errors.UnknownConfigValueError):
+    config = picofun.config.Config()
+    with pytest.raises(
+        AttributeError, match="'Config' object has no attribute 'invalid'"
+    ):
         _ = config.invalid
 
 
 def test_config_setattr_invalid() -> None:
-    """Test splitting layers string into a list."""
-    config = picofun.config.Config("tests/data/empty.toml")
+    """Test setting invalid attribute."""
+    config = picofun.config.Config()
 
-    with pytest.raises(picofun.errors.UnknownConfigValueError):
+    with pytest.raises(pydantic.ValidationError):
         config.invalid = "invalid"
-
-
-def test_config_setattr_layers_empty() -> None:
-    """Test splitting layers string into a list."""
-    config = picofun.config.Config("tests/data/empty.toml")
-
-    config.layers = ""
-    assert config.layers == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
-
-
-def test_config_setattr_layers() -> None:
-    """Test splitting layers string into a list."""
-    layers = [
-        "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
-        "arn:aws:lambda:us-east-1:012345678910:layer:anotherexample:123",
-        picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
-    ]
-
-    config = picofun.config.Config("tests/data/empty.toml")
-    assert config.layers == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
-
-    config.layers = ", ".join(layers)
-    assert config.layers == layers
 
 
 def test_config_setattr_layers_powertools() -> None:
@@ -123,222 +46,18 @@ def test_config_setattr_layers_powertools() -> None:
         "arn:aws:lambda:us-east-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"
     ]
 
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
     assert config.layers == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
 
     config.layers = layers
     assert config.layers == layers
 
 
-def test_config_load_absolute_path() -> None:
-    """Test loading a configuration file with an absolute path."""
-    config = picofun.config.Config(os.path.realpath("tests/data/config.toml"))
-
-    assert config.output_dir == os.path.realpath("tests/data/output")
-
-
-def test_fix_target_path_relative() -> None:
-    """Test fixing the target path with a realtive path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("tests/data") == os.path.realpath("tests/data")
-
-
-def test_fix_target_path_absolute() -> None:
-    """Test fixing the target path with an absolute path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("/tmp") == os.path.realpath("/tmp")
-
-
-def test_fix_target_path_dots() -> None:
-    """Test fixing the target path containing dots."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("tests/../tests/data") == os.path.realpath(
-        "tests/data"
-    )
-
-
-def test_fix_target_path_empty() -> None:
-    """Test fixing the target path with an empty path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("") == os.path.realpath(os.getcwd())
-
-
-def test_fix_target_path_none() -> None:
-    """Test fixing the target path with an empty path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path() == os.path.realpath(os.getcwd())
-
-
-def test_fix_target_path_missing() -> None:
-    """Test fixing the target path with an empty path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("missing") == os.path.realpath(
-        os.path.join(os.getcwd(), "missing")
-    )
-
-
-def test_fix_target_path_missing_absolute() -> None:
-    """Test fixing the target path with an empty path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("/missing") == os.path.realpath("/missing")
-
-
-def test_fix_target_path_missing_relative() -> None:
-    """Test fixing the target path with an empty path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_target_path("missing") == os.path.realpath(
-        os.path.join(os.getcwd(), "missing")
-    )
-
-
-def test_fix_bundle_path_relative() -> None:
-    """Test fixing the bundle path with a realtive path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_bundle_path("subdir") == os.path.realpath("tests/data/subdir")
-
-
-def test_fix_bundle_path_absolute() -> None:
-    """Test fixing the bundle path with an absolute path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_bundle_path("/tmp") == os.path.realpath("/tmp")
-
-
-def test_fix_bundle_path_dots() -> None:
-    """Test fixing the bundle path containing dots."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_bundle_path("../data") == os.path.realpath("tests/data")
-
-
-def test_fix_bundle_path_empty() -> None:
-    """Test fixing the bundle path with an empty path."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    assert config._fix_bundle_path("") == os.path.realpath("tests/data")
-
-
-def test_load_from_file() -> None:
-    """Test loading a configuration file."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    with tempfile.NamedTemporaryFile() as tmp:
-        tmp.write(b"output_dir = 'tests/data/output'")
-        tmp.seek(0)
-
-        config.load_from_file(tmp.name)
-
-        assert config.output_dir == os.path.realpath("tests/data/output")
-
-
-def test_load_from_file_missing() -> None:
-    """Test loading a configuration file."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    with pytest.raises(picofun.errors.ConfigFileNotFoundError):
-        config.load_from_file(
-            "/tmp/invalid/config/file/location/45c5391e-6e9a-496e-8694-9ef1a03addb3.toml"
-        )
-
-
-def test_load_from_file_invalid() -> None:
-    """Test loading a configuration file."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    with tempfile.NamedTemporaryFile() as tmp:
-        tmp.write(b"this = invalid = toml")
-        tmp.seek(0)
-
-        with pytest.raises(picofun.errors.InvalidConfigError):
-            config.load_from_file(tmp.name)
-
-
-def test_merge() -> None:
-    """Test merging two configurations."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    config.merge(output_dir="tests/output")
-
-    assert config.output_dir == os.path.realpath("tests/output")
-
-
-def test_merge_invalid() -> None:
-    """Test merging two configurations."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    with pytest.raises(picofun.errors.UnknownConfigValueError):
-        config.merge(invalid="invalid")
-
-
-def test_merge_invalid_type() -> None:
-    """Test merging two configurations."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    with pytest.raises(picofun.errors.InvalidConfigTypeError):
-        config.merge(output_dir=1234)
-
-
-def test_set_defaults() -> None:
-    """Test setting defaults."""
-    config = picofun.config.Config("tests/data/empty.toml")
-
-    config.set_defaults()
-
-    assert config.bundle is None
-    assert config.layers == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
-
-
-def test_asdict() -> None:
-    """Test converting the config to a dictionary."""
-    config = picofun.config.Config("tests/data/config.toml")
-
-    config_dict = config.asdict()
-
-    assert isinstance(config_dict, dict)
-
-    assert config_dict["output_dir"] == os.path.realpath("tests/data/output")
-
-
-def test_asdict_empty() -> None:
-    """Test converting the config to a dictionary."""
-    config = picofun.config.Config("tests/data/empty.toml")
-
-    assert config.asdict()["layers"] == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
-
-
-def test_get_config_file() -> None:
-    """Test getting the path to the config file."""
-    path = os.path.join(os.path.dirname(__file__), "data")
-    config = picofun.config.Config(path)
-    assert config._config_file == f"{path}/picofun.toml"
-
-
-def test_get_config_file_empty() -> None:
-    """Test getting the path to the config file with an empty argument."""
-    path = os.getcwd()
-    config = picofun.config.Config()
-    assert config._config_file == f"{path}/picofun.toml"
-
-
-def test_get_config_file_invalid() -> None:
-    """Test not getting the config file from an invalid path."""
-    with pytest.raises(picofun.errors.ConfigFileNotFoundError):
-        picofun.config.Config("/invalid/")
-
-
-def test_setattr_output_dir_mkdir() -> None:
+def test_config_setattr_output_dir_mkdir() -> None:
     """Test creating the output directory."""
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
 
+    # Can't use tempfile.mkdtemp as it creates the directory
     tmp = os.path.realpath(
         f'/tmp/picofun_tests_{"".join(random.sample(string.ascii_letters + string.digits, 16))}'
     )
@@ -348,3 +67,305 @@ def test_setattr_output_dir_mkdir() -> None:
     assert os.path.exists(tmp)
 
     os.rmdir(tmp)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("tests/data", "tests/data"),
+        ("/tmp", "/tmp"),
+        ("tests/data/../data", "tests/data"),
+    ],
+)
+def test_config_bundle_validation(path: str, expected: str) -> None:
+    """Test bundle validation."""
+    assert picofun.config.Config.validate_bundle(path) == os.path.realpath(expected)
+
+
+def test_config_bundle_validation_not_found() -> None:
+    """Test bundle validation."""
+    with pytest.raises(
+        ValueError, match="Bundle path not found: /this/path/does/not/exist"
+    ):
+        assert picofun.config.Config.validate_bundle("/this/path/does/not/exist")
+
+
+@pytest.mark.parametrize(
+    ("layers", "expected"),
+    [
+        ("", [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]),
+        (
+            "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
+            [
+                picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
+                "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
+            ],
+        ),
+        (
+            ["arn:aws:lambda:us-east-1:012345678910:layer:example:1"],
+            [
+                picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
+                "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
+            ],
+        ),
+        (
+            [
+                "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
+                picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
+            ],
+            [
+                "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
+                picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
+            ],
+        ),
+        (
+            "arn:aws:lambda:us-east-1:012345678910:layer:example:1, arn:aws:lambda:us-east-1:012345678910:layer:example:2",
+            [
+                picofun.config.AWS_POWER_TOOLS_LAYER_ARN,
+                "arn:aws:lambda:us-east-1:012345678910:layer:example:1",
+                "arn:aws:lambda:us-east-1:012345678910:layer:example:2",
+            ],
+        ),
+    ],
+)
+def test_config_validate_layers(layers: list, expected: list) -> None:
+    """Test layers validation."""
+    assert picofun.config.Config.validate_layers(layers) == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("tests/data", "tests/data"),
+        ("/tmp", "/tmp"),
+        ("tests/data/../data", "tests/data"),
+        ("", os.getcwd()),
+    ],
+)
+def test_config_output_dir_validator(path: str, expected: str) -> None:
+    """Test the outpath validator."""
+    assert picofun.config.Config.validate_output_dir(path) == os.path.realpath(expected)
+
+
+@pytest.mark.parametrize(
+    ("subnets", "expected"),
+    [
+        ("", []),
+        ("subnet-12345678", ["subnet-12345678"]),
+        (["subnet-12345678"], ["subnet-12345678"]),
+        (
+            ["subnet-12345678", "subnet-87654321"],
+            ["subnet-12345678", "subnet-87654321"],
+        ),
+        ("subnet-12345678, subnet-87654321", ["subnet-12345678", "subnet-87654321"]),
+    ],
+)
+def test_config_validate_subnets(subnets: list, expected: list) -> None:
+    """Test subnets validation."""
+    assert picofun.config.Config.validate_subnets(subnets) == expected
+
+
+def test_config_validate_subnets_invalid() -> None:
+    """Test subnets validation with invalid subnet id."""
+    with pytest.raises(
+        ValueError, match=r"Subnets must be in the format 'subnet-\[hex\]'"
+    ):
+        picofun.config.Config.validate_subnets("invalid")
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("tests/data/templates", "tests/data/templates"),
+        (os.path.realpath("tests/data/templates"), "tests/data/templates"),
+    ],
+)
+def test_config_validate_template_path(path: str, expected: str) -> None:
+    """Test the template path validator."""
+    assert picofun.config.Config.validate_template_path(path) == os.path.realpath(
+        expected
+    )
+
+
+def test_config_validate_template_path_not_found() -> None:
+    """Test the template path validator."""
+    with pytest.raises(
+        ValueError, match="Template path not found: /this/path/does/not/exist"
+    ):
+        picofun.config.Config.validate_template_path("/this/path/does/not/exist")
+
+
+@pytest.mark.parametrize(
+    ("vpc_id", "subnets", "expected"),
+    [
+        (
+            "vpc-12345678",
+            "subnet-12345678",
+            {"vpc_id": "vpc-12345678", "subnets": ["subnet-12345678"]},
+        ),
+        (
+            "vpc-12345678",
+            ["subnet-12345678"],
+            {"vpc_id": "vpc-12345678", "subnets": ["subnet-12345678"]},
+        ),
+        (
+            "vpc-12345678",
+            ["subnet-12345678", "subnet-87654321"],
+            {
+                "vpc_id": "vpc-12345678",
+                "subnets": ["subnet-12345678", "subnet-87654321"],
+            },
+        ),
+        (
+            "vpc-12345678",
+            "subnet-12345678, subnet-87654321",
+            {
+                "vpc_id": "vpc-12345678",
+                "subnets": ["subnet-12345678", "subnet-87654321"],
+            },
+        ),
+    ],
+)
+def test_config_validate_subnets_vpc(
+    vpc_id: str, subnets: list, expected: dict[str : typing.Union[str | list]]
+) -> None:
+    """Test subnets VPC validation."""
+    params = {"vpc_id": vpc_id, "subnets": subnets}
+    config = picofun.config.Config(**params)
+
+    assert config.vpc_id == expected["vpc_id"]
+    assert config.subnets == expected["subnets"]
+
+
+@pytest.mark.parametrize(
+    ("vpc_id", "subnets"),
+    [
+        ("vpc-12345678", ""),
+        ("vpc-12345678", []),
+        ("", "subnet-12345678"),
+        ("", "subnet-12345678, subnet-87654321"),
+    ],
+)
+def test_config_validate_subnets_vpc_invalid(vpc_id: str, subnets: list) -> None:
+    """Test subnets VPC validation with invalid configuration."""
+    params = {"vpc_id": vpc_id, "subnets": subnets}
+    with pytest.raises(
+        ValueError, match="Both subnets and vpc must be set, if one is set"
+    ):
+        picofun.config.Config(**params)
+
+
+def test_config_merge() -> None:
+    """Test merging two configurations."""
+    config = picofun.config.Config()
+
+    config.merge(output_dir="tests/output")
+
+    assert str(config.output_dir) == os.path.realpath("tests/output")
+
+
+def test_config_merge_invalid() -> None:
+    """Test merging configuration with an invalid property."""
+    config = picofun.config.Config()
+
+    with pytest.raises(pydantic.ValidationError, match="1 validation error for Config"):
+        config.merge(output_dir="tests/output", invalid="invalid")
+
+
+def test_config_merge_invalid_type() -> None:
+    """Test merging configurations with invalid data type for the property."""
+    config = picofun.config.Config()
+
+    with pytest.raises(
+        TypeError, match="expected str, bytes or os.PathLike object, not int"
+    ):
+        config.merge(output_dir=1234)
+
+
+def test_config_dump_model() -> None:
+    """Test converting the config to a dictionary."""
+    config = picofun.config.Config()
+
+    config_dict = config.model_dump()
+
+    assert isinstance(config_dict, dict)
+
+    assert config_dict["output_dir"] == os.path.realpath("output")
+
+
+def test_configloader() -> None:
+    """Test getting the path to the config file with an empty argument."""
+    path = os.getcwd()
+    loader = picofun.config.ConfigLoader()
+
+    assert loader._config_file == f"{path}/picofun.toml"
+    assert isinstance(loader._config, picofun.config.Config)
+    assert len(loader._config.layers) == 1
+
+
+def test_configloader_with_file() -> None:
+    """Test loading a configuration file."""
+    loader = picofun.config.ConfigLoader("tests/data/config.toml")
+
+    assert loader._config_file == "tests/data/config.toml"
+    assert len(loader._config.layers) == 2
+
+
+def test_configloader_empty_file() -> None:
+    """Test loading an empty configuration file."""
+    loader = picofun.config.ConfigLoader("tests/data/empty.toml")
+
+    assert loader._config.output_dir == os.path.realpath(f"{os.getcwd()}/output")
+    assert loader._config.layers == [picofun.config.AWS_POWER_TOOLS_LAYER_ARN]
+
+
+@pytest.mark.parametrize(
+    ("config_file", "exception_type"),
+    [
+        ("tests/data/missing.toml", picofun.errors.ConfigFileNotFoundError),
+        ("tests/data/invalid.toml", picofun.errors.InvalidConfigError),
+        ("tests/data/invalid_type.toml", picofun.errors.UnknownConfigValueError),
+        ("/this/file/doesnt/exist.toml", picofun.errors.ConfigFileNotFoundError),
+    ],
+)
+def test_configloader_errors(config_file: str, exception_type: Exception) -> None:
+    """Test loading a missing configuration file."""
+    with pytest.raises(exception_type):
+        picofun.config.ConfigLoader(os.path.realpath(config_file))
+
+
+def test_configloader_relative_path() -> None:
+    """Test loading a configuration file with a relative path."""
+    loader = picofun.config.ConfigLoader("tests/data/config_relative.toml")
+
+    assert str(loader._config.output_dir) == os.path.realpath("tests/data/output")
+
+
+def test_configloader_absolute_path() -> None:
+    """Test loading a configuration file with an absolute path."""
+    path = os.path.join(os.path.dirname(__file__), "data")
+    loader = picofun.config.ConfigLoader(path)
+    assert loader._config_file == f"{path}/picofun.toml"
+
+
+def test_configloader_from_file_invalid() -> None:
+    """Test loading a configuration file."""
+    loader = picofun.config.ConfigLoader("tests/data/config.toml")
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(b"this = invalid = toml")
+        tmp.seek(0)
+
+        with pytest.raises(picofun.errors.InvalidConfigError):
+            loader.load_from_file(tmp.name)
+
+
+def test_configloader_get_config() -> None:
+    """Test getting the configuration object."""
+    loader = picofun.config.ConfigLoader("tests/data/config.toml")
+
+    config = loader.get_config()
+
+    assert isinstance(config, picofun.config.Config)
+    assert len(config.layers) == 2
+    assert str(config.output_dir) == os.path.realpath("tests/data/output")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -47,7 +47,7 @@ def test_invalid_spec_error() -> None:
 def test_unknown_config_value_error() -> None:
     """Test UnknownConfigValueError."""
     with pytest.raises(picofun.errors.UnknownConfigValueError):
-        raise picofun.errors.UnknownConfigValueError("missing")
+        raise picofun.errors.UnknownConfigValueError()
 
 
 def test_invalid_config_type_error() -> None:

--- a/tests/test_lambda_generator.py
+++ b/tests/test_lambda_generator.py
@@ -10,7 +10,9 @@ import picofun.template
 def test_get_name() -> None:
     """Test getting the name of the lambda."""
     tpl = picofun.template.Template("tests/data/templates")
-    generator = picofun.lambda_generator.LambdaGenerator(tpl, "", "tests/data/lambda")
+    generator = picofun.lambda_generator.LambdaGenerator(
+        tpl, "", picofun.config.Config()
+    )
 
     assert generator._get_name("method", "path") == "method_path"
 
@@ -18,7 +20,9 @@ def test_get_name() -> None:
 def test_get_name_with_dot() -> None:
     """Test getting the name of the lambda when path contains a dot (.)."""
     tpl = picofun.template.Template("tests/data/templates")
-    generator = picofun.lambda_generator.LambdaGenerator(tpl, "", "tests/data/lambda")
+    generator = picofun.lambda_generator.LambdaGenerator(
+        tpl, "", picofun.config.Config()
+    )
 
     assert generator._get_name("method", "path.json") == "method_path_json"
 
@@ -27,7 +31,7 @@ def test_get_name_too_long() -> None:
     """Test getting the name of the lambda."""
     tpl = picofun.template.Template("tests/data/templates")
     generator = picofun.lambda_generator.LambdaGenerator(
-        tpl, "prefix", "tests/data/lambda"
+        tpl, "prefix", picofun.config.Config()
     )
 
     path = "how_long_does_this_string_need_to_be_before_it_is_truncated_by_get_name"
@@ -63,7 +67,7 @@ def test_generate() -> None:
     }
 
     tpl = picofun.template.Template("tests/data/templates")
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
     with tempfile.TemporaryDirectory() as out_dir:
         config.output_dir = out_dir
         generator = picofun.lambda_generator.LambdaGenerator(tpl, "", config)
@@ -97,7 +101,7 @@ def test_generate_empty() -> None:
     }
 
     tpl = picofun.template.Template("tests/data/templates")
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
 
     with tempfile.TemporaryDirectory() as out_dir:
         config.output_dir = out_dir
@@ -110,7 +114,7 @@ def test_generate_invalid_method() -> None:
     spec = {"servers": [{"url": "https://example.com"}], "paths": {}}
 
     tpl = picofun.template.Template("tests/data/templates")
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
 
     with tempfile.TemporaryDirectory() as out_dir:
         config.output_dir = out_dir
@@ -121,7 +125,7 @@ def test_generate_invalid_method() -> None:
 def test_render() -> None:
     """Test rendering the lambda."""
     tpl = picofun.template.Template("tests/data/templates")
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
     generator = picofun.lambda_generator.LambdaGenerator(tpl, "", config)
 
     code = generator.render("https://example.com", "get", "/path", {})

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -9,7 +9,7 @@ import picofun.layer
 
 def test_prepare() -> None:
     """Test generating the layer."""
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
     with tempfile.TemporaryDirectory() as out_dir:
         config.output_dir = out_dir
         layer = picofun.layer.Layer(config)
@@ -20,7 +20,7 @@ def test_prepare() -> None:
 
 def test_prepare_with_bundle() -> None:
     """Test generating the layer."""
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
 
     with tempfile.TemporaryDirectory() as bundle_dir:
         config.bundle = bundle_dir

--- a/tests/test_terraform_generator.py
+++ b/tests/test_terraform_generator.py
@@ -9,7 +9,7 @@ import picofun.terraform_generator
 
 def test_generate() -> None:
     """Test generating the terraform configuration."""
-    config = picofun.config.Config("tests/data/empty.toml")
+    config = picofun.config.Config()
     tpl = picofun.template.Template("tests/data/templates")
     with tempfile.TemporaryDirectory() as out_dir:
         config.output_dir = out_dir


### PR DESCRIPTION
**Breaking Changes**

Use ARM64 runtime to match the default Powertools layer. To be configurable in the future.

Switch to pydantic as it is more robust than my home brew solution. This makes adding additional configuration options in the future easier.

Split the configuration loading from the config class. `ConfigLoader` is responsible for loading the config. `Config` still managed the configuration.

Refactored the tests to make them easier to maintain. Many are now parameterised.

`vpc_id` is now required if using `subnets` in config. When using a shared VPC the subnet data sources may not be available. While this adds some redundant config it makes things more robust.